### PR TITLE
Remove a '!' from the logic of filtering tags

### DIFF
--- a/src/Policies/InteractPolicy.php
+++ b/src/Policies/InteractPolicy.php
@@ -49,7 +49,7 @@ class InteractPolicy
         if (! $this->feature->tags()) return $authorizations;
 
         return $authorizations
-            ->filter(fn (Agent\Authorization $authorization) => ! $this->tagWildCarded($authorization) || $authorization->tags()->intersect($tags)->isNotEmpty());
+            ->filter(fn (Agent\Authorization $authorization) => $this->tagWildCarded($authorization) || $authorization->tags()->intersect($tags)->isNotEmpty());
     }
 
     protected function tagWildCarded(Agent\Authorization $authorization): bool


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**

Change the logic of filtering tags.

- Before: not wildcard or have intersect (which is always true if we are not using a wildcard tag name.
- After: wildcard or have intersect.

**Reviewers should focus on:**
If the following bug is fixed.
<img width="736" alt="Snipaste_2024-09-23_02-23-19" src="https://github.com/user-attachments/assets/85f3b60c-ee19-45b5-9722-2db34c4ac6f7">

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Maintainer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
